### PR TITLE
Fix for Repeatedly Calling `MathOptInterface.AbstractOptimizer` objects

### DIFF
--- a/docs/OrdinalMultinomialModels.ipynb
+++ b/docs/OrdinalMultinomialModels.ipynb
@@ -534,20 +534,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "******************************************************************************\n",
-      "This program contains Ipopt, a library for large-scale nonlinear optimization.\n",
-      " Ipopt is released as open source code under the Eclipse Public License (EPL).\n",
-      "         For more information visit https://github.com/coin-or/Ipopt\n",
-      "******************************************************************************\n",
-      "\n",
       "Total number of variables............................:        8\n",
       "                     variables with only lower bounds:        0\n",
       "                variables with lower and upper bounds:        0\n",
@@ -576,8 +569,8 @@
       "Number of equality constraint Jacobian evaluations   = 0\n",
       "Number of inequality constraint Jacobian evaluations = 0\n",
       "Number of Lagrangian Hessian evaluations             = 0\n",
-      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.352\n",
-      "Total CPU secs in NLP function evaluations           =      0.052\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.103\n",
+      "Total CPU secs in NLP function evaluations           =      0.002\n",
       "\n",
       "EXIT: Optimal Solution Found.\n"
      ]
@@ -604,7 +597,7 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +870,7 @@
     {
      "data": {
       "text/plain": [
-       "0.03701281106104201"
+       "0.8365377486560666"
       ]
      },
      "execution_count": 21,
@@ -905,7 +898,7 @@
     {
      "data": {
       "text/plain": [
-       "2.2761093170953646e-21"
+       "1.539797875970353e-80"
       ]
      },
      "execution_count": 22,

--- a/docs/OrdinalMultinomialModels.ipynb
+++ b/docs/OrdinalMultinomialModels.ipynb
@@ -77,7 +77,7 @@
     {
      "data": {
       "text/html": [
-       "<div class=\"data-frame\"><p>72 rows × 5 columns</p><table class=\"data-frame\"><thead><tr><th></th><th>Sat</th><th>Infl</th><th>Type</th><th>Cont</th><th>Freq</th></tr><tr><th></th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"Int32\">Int32</th></tr></thead><tbody><tr><th>1</th><td>Low</td><td>Low</td><td>Tower</td><td>Low</td><td>21</td></tr><tr><th>2</th><td>Medium</td><td>Low</td><td>Tower</td><td>Low</td><td>21</td></tr><tr><th>3</th><td>High</td><td>Low</td><td>Tower</td><td>Low</td><td>28</td></tr><tr><th>4</th><td>Low</td><td>Medium</td><td>Tower</td><td>Low</td><td>34</td></tr><tr><th>5</th><td>Medium</td><td>Medium</td><td>Tower</td><td>Low</td><td>22</td></tr><tr><th>6</th><td>High</td><td>Medium</td><td>Tower</td><td>Low</td><td>36</td></tr><tr><th>7</th><td>Low</td><td>High</td><td>Tower</td><td>Low</td><td>10</td></tr><tr><th>8</th><td>Medium</td><td>High</td><td>Tower</td><td>Low</td><td>11</td></tr><tr><th>9</th><td>High</td><td>High</td><td>Tower</td><td>Low</td><td>36</td></tr><tr><th>10</th><td>Low</td><td>Low</td><td>Apartment</td><td>Low</td><td>61</td></tr><tr><th>11</th><td>Medium</td><td>Low</td><td>Apartment</td><td>Low</td><td>23</td></tr><tr><th>12</th><td>High</td><td>Low</td><td>Apartment</td><td>Low</td><td>17</td></tr><tr><th>13</th><td>Low</td><td>Medium</td><td>Apartment</td><td>Low</td><td>43</td></tr><tr><th>14</th><td>Medium</td><td>Medium</td><td>Apartment</td><td>Low</td><td>35</td></tr><tr><th>15</th><td>High</td><td>Medium</td><td>Apartment</td><td>Low</td><td>40</td></tr><tr><th>16</th><td>Low</td><td>High</td><td>Apartment</td><td>Low</td><td>26</td></tr><tr><th>17</th><td>Medium</td><td>High</td><td>Apartment</td><td>Low</td><td>18</td></tr><tr><th>18</th><td>High</td><td>High</td><td>Apartment</td><td>Low</td><td>54</td></tr><tr><th>19</th><td>Low</td><td>Low</td><td>Atrium</td><td>Low</td><td>13</td></tr><tr><th>20</th><td>Medium</td><td>Low</td><td>Atrium</td><td>Low</td><td>9</td></tr><tr><th>21</th><td>High</td><td>Low</td><td>Atrium</td><td>Low</td><td>10</td></tr><tr><th>22</th><td>Low</td><td>Medium</td><td>Atrium</td><td>Low</td><td>8</td></tr><tr><th>23</th><td>Medium</td><td>Medium</td><td>Atrium</td><td>Low</td><td>8</td></tr><tr><th>24</th><td>High</td><td>Medium</td><td>Atrium</td><td>Low</td><td>12</td></tr><tr><th>25</th><td>Low</td><td>High</td><td>Atrium</td><td>Low</td><td>6</td></tr><tr><th>26</th><td>Medium</td><td>High</td><td>Atrium</td><td>Low</td><td>7</td></tr><tr><th>27</th><td>High</td><td>High</td><td>Atrium</td><td>Low</td><td>9</td></tr><tr><th>28</th><td>Low</td><td>Low</td><td>Terrace</td><td>Low</td><td>18</td></tr><tr><th>29</th><td>Medium</td><td>Low</td><td>Terrace</td><td>Low</td><td>6</td></tr><tr><th>30</th><td>High</td><td>Low</td><td>Terrace</td><td>Low</td><td>7</td></tr><tr><th>&vellip;</th><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td></tr></tbody></table></div>"
+       "<div class=\"data-frame\"><p>72 rows × 5 columns</p><table class=\"data-frame\"><thead><tr><th></th><th>Sat</th><th>Infl</th><th>Type</th><th>Cont</th><th>Freq</th></tr><tr><th></th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"CategoricalArrays.CategoricalValue{String, UInt8}\">Cat…</th><th title=\"Int32\">Int32</th></tr></thead><tbody><tr><th>1</th><td>Low</td><td>Low</td><td>Tower</td><td>Low</td><td>21</td></tr><tr><th>2</th><td>Medium</td><td>Low</td><td>Tower</td><td>Low</td><td>21</td></tr><tr><th>3</th><td>High</td><td>Low</td><td>Tower</td><td>Low</td><td>28</td></tr><tr><th>4</th><td>Low</td><td>Medium</td><td>Tower</td><td>Low</td><td>34</td></tr><tr><th>5</th><td>Medium</td><td>Medium</td><td>Tower</td><td>Low</td><td>22</td></tr><tr><th>6</th><td>High</td><td>Medium</td><td>Tower</td><td>Low</td><td>36</td></tr><tr><th>7</th><td>Low</td><td>High</td><td>Tower</td><td>Low</td><td>10</td></tr><tr><th>8</th><td>Medium</td><td>High</td><td>Tower</td><td>Low</td><td>11</td></tr><tr><th>9</th><td>High</td><td>High</td><td>Tower</td><td>Low</td><td>36</td></tr><tr><th>10</th><td>Low</td><td>Low</td><td>Apartment</td><td>Low</td><td>61</td></tr><tr><th>11</th><td>Medium</td><td>Low</td><td>Apartment</td><td>Low</td><td>23</td></tr><tr><th>12</th><td>High</td><td>Low</td><td>Apartment</td><td>Low</td><td>17</td></tr><tr><th>13</th><td>Low</td><td>Medium</td><td>Apartment</td><td>Low</td><td>43</td></tr><tr><th>14</th><td>Medium</td><td>Medium</td><td>Apartment</td><td>Low</td><td>35</td></tr><tr><th>15</th><td>High</td><td>Medium</td><td>Apartment</td><td>Low</td><td>40</td></tr><tr><th>16</th><td>Low</td><td>High</td><td>Apartment</td><td>Low</td><td>26</td></tr><tr><th>17</th><td>Medium</td><td>High</td><td>Apartment</td><td>Low</td><td>18</td></tr><tr><th>18</th><td>High</td><td>High</td><td>Apartment</td><td>Low</td><td>54</td></tr><tr><th>19</th><td>Low</td><td>Low</td><td>Atrium</td><td>Low</td><td>13</td></tr><tr><th>20</th><td>Medium</td><td>Low</td><td>Atrium</td><td>Low</td><td>9</td></tr><tr><th>21</th><td>High</td><td>Low</td><td>Atrium</td><td>Low</td><td>10</td></tr><tr><th>22</th><td>Low</td><td>Medium</td><td>Atrium</td><td>Low</td><td>8</td></tr><tr><th>23</th><td>Medium</td><td>Medium</td><td>Atrium</td><td>Low</td><td>8</td></tr><tr><th>24</th><td>High</td><td>Medium</td><td>Atrium</td><td>Low</td><td>12</td></tr><tr><th>&vellip;</th><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td><td>&vellip;</td></tr></tbody></table></div>"
       ],
       "text/latex": [
        "\\begin{tabular}{r|ccccc}\n",
@@ -109,12 +109,6 @@
        "\t22 & Low & Medium & Atrium & Low & 8 \\\\\n",
        "\t23 & Medium & Medium & Atrium & Low & 8 \\\\\n",
        "\t24 & High & Medium & Atrium & Low & 12 \\\\\n",
-       "\t25 & Low & High & Atrium & Low & 6 \\\\\n",
-       "\t26 & Medium & High & Atrium & Low & 7 \\\\\n",
-       "\t27 & High & High & Atrium & Low & 9 \\\\\n",
-       "\t28 & Low & Low & Terrace & Low & 18 \\\\\n",
-       "\t29 & Medium & Low & Terrace & Low & 6 \\\\\n",
-       "\t30 & High & Low & Terrace & Low & 7 \\\\\n",
        "\t$\\dots$ & $\\dots$ & $\\dots$ & $\\dots$ & $\\dots$ & $\\dots$ \\\\\n",
        "\\end{tabular}\n"
       ],
@@ -131,13 +125,7 @@
        "   6 │ High    Medium  Tower      Low      36\n",
        "   7 │ Low     High    Tower      Low      10\n",
        "   8 │ Medium  High    Tower      Low      11\n",
-       "   9 │ High    High    Tower      Low      36\n",
-       "  10 │ Low     Low     Apartment  Low      61\n",
-       "  11 │ Medium  Low     Apartment  Low      23\n",
        "  ⋮  │   ⋮       ⋮         ⋮       ⋮      ⋮\n",
-       "  63 │ High    High    Atrium     High     21\n",
-       "  64 │ Low     Low     Terrace    High     57\n",
-       "  65 │ Medium  Low     Terrace    High     23\n",
        "  66 │ High    Low     Terrace    High     13\n",
        "  67 │ Low     Medium  Terrace    High     31\n",
        "  68 │ Medium  Medium  Terrace    High     21\n",
@@ -145,12 +133,11 @@
        "  70 │ Low     High    Terrace    High      5\n",
        "  71 │ Medium  High    Terrace    High      6\n",
        "  72 │ High    High    Terrace    High     13\n",
-       "\u001b[36m                               51 rows omitted\u001b[0m"
+       "\u001b[36m                               57 rows omitted\u001b[0m"
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -175,9 +162,8 @@
        "(72, 1681)"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -234,9 +220,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -263,9 +248,8 @@
        "3479.1492990725856"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -298,9 +282,8 @@
        "  0.3602844417528419"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -333,9 +316,8 @@
        " 0.09535742939732537"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -378,9 +360,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -398,9 +379,8 @@
        "3479.6888425652414"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -443,9 +423,8 @@
        "───────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -463,9 +442,8 @@
        "3484.0532214401615"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -490,9 +468,8 @@
        "(3479.1492990725856, 3479.6888425652414, 3484.0532214401615)"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -534,13 +511,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "******************************************************************************\n",
+      "This program contains Ipopt, a library for large-scale nonlinear optimization.\n",
+      " Ipopt is released as open source code under the Eclipse Public License (EPL).\n",
+      "         For more information visit https://github.com/coin-or/Ipopt\n",
+      "******************************************************************************\n",
+      "\n",
       "Total number of variables............................:        8\n",
       "                     variables with only lower bounds:        0\n",
       "                variables with lower and upper bounds:        0\n",
@@ -569,8 +553,8 @@
       "Number of equality constraint Jacobian evaluations   = 0\n",
       "Number of inequality constraint Jacobian evaluations = 0\n",
       "Number of Lagrangian Hessian evaluations             = 0\n",
-      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.103\n",
-      "Total CPU secs in NLP function evaluations           =      0.002\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.148\n",
+      "Total CPU secs in NLP function evaluations           =      0.024\n",
       "\n",
       "EXIT: Optimal Solution Found.\n"
      ]
@@ -597,9 +581,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 25,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -643,9 +626,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -689,9 +671,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 16,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -738,9 +719,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -765,9 +745,8 @@
        "0.0001553518554532406"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -814,9 +793,8 @@
        "─────────────────────────────────────────────────────────"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -841,9 +819,8 @@
        "0.00016487435975878276"
       ]
      },
-     "execution_count": 20,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -870,12 +847,11 @@
     {
      "data": {
       "text/plain": [
-       "0.8365377486560666"
+       "7.074652360944771e-25"
       ]
      },
-     "execution_count": 21,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -898,12 +874,11 @@
     {
      "data": {
       "text/plain": [
-       "1.539797875970353e-80"
+       "4.352077675175147e-18"
       ]
      },
-     "execution_count": 22,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [

--- a/src/ordmnfit.jl
+++ b/src/ordmnfit.jl
@@ -186,6 +186,7 @@ function fit(
     T = eltype(X)
     ydata = Vector{Int}(undef, size(y, 1))
     # set up optimization
+    MOI.empty!(solver)
     # This is a hack since we can't initialize a solver with parameters already set
     if typeof(solver) == NLopt.Optimizer
         algo = MOI.get(solver, MOI.RawOptimizerAttribute("algorithm"))


### PR DESCRIPTION
I believe I figured out what was the issue for the Likelihood Ratio tests in OrdinalGWAS, the issue was that the attached solver variables weren't being removed before a subsequent call involving the solver. The fix was simply adding `MathOptInterface.empty!()` to the `fit` function during the initialization step with the solver.